### PR TITLE
Feat/clutterstate

### DIFF
--- a/Assets/Scenes/PossessionScene.unity
+++ b/Assets/Scenes/PossessionScene.unity
@@ -413,6 +413,7 @@ GameObject:
   - component: {fileID: 152132489}
   - component: {fileID: 152132488}
   - component: {fileID: 152132487}
+  - component: {fileID: 152132494}
   m_Layer: 0
   m_Name: Object 1
   m_TagString: Untagged
@@ -675,6 +676,22 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 152132485}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &152132494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 152132485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6de1a478009c8414e9303b12dd63f349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MoveAnxietyValue: 2
+  DestroyAnxietyValue: 10
+  AuditoryMultiplier: 1
+  VisualMultiplier: 3
 --- !u!1 &200849597
 GameObject:
   m_ObjectHideFlags: 3
@@ -3220,6 +3237,7 @@ GameObject:
   - component: {fileID: 1206899723}
   - component: {fileID: 1206899730}
   - component: {fileID: 1206899731}
+  - component: {fileID: 1206899732}
   m_Layer: 0
   m_Name: Object 3
   m_TagString: Untagged
@@ -3482,6 +3500,22 @@ MonoBehaviour:
   renderers:
   - {fileID: 1206899728}
   highlightColor: {r: 1, g: 1, b: 1, a: 1}
+--- !u!114 &1206899732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1206899721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6de1a478009c8414e9303b12dd63f349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MoveAnxietyValue: 2
+  DestroyAnxietyValue: 10
+  AuditoryMultiplier: 1
+  VisualMultiplier: 3
 --- !u!1 &1259284987
 GameObject:
   m_ObjectHideFlags: 3
@@ -3577,6 +3611,7 @@ GameObject:
   - component: {fileID: 1327424715}
   - component: {fileID: 1327424714}
   - component: {fileID: 1327424713}
+  - component: {fileID: 1327424720}
   m_Layer: 0
   m_Name: Object 2
   m_TagString: Untagged
@@ -3839,6 +3874,22 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1327424711}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &1327424720
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1327424711}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6de1a478009c8414e9303b12dd63f349, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MoveAnxietyValue: 2
+  DestroyAnxietyValue: 10
+  AuditoryMultiplier: 1
+  VisualMultiplier: 3
 --- !u!1 &1359245195 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4416926081852918481, guid: 64dce48905ffd9b4293e595fa6941544,

--- a/Assets/Scripts/Possession/Throwable.cs
+++ b/Assets/Scripts/Possession/Throwable.cs
@@ -75,11 +75,6 @@ public class Throwable : MonoBehaviour, IPossessable
             {
                 ThrowObject();
             }
-            if (Input.GetKeyDown(KeyCode.X))
-            {
-                Debug.Log(_clutter.State);
-                Debug.Log(_rb.velocity.magnitude);
-            }
         }
     }
 
@@ -119,7 +114,6 @@ public class Throwable : MonoBehaviour, IPossessable
         if (collision.impulse.magnitude > 0.1f)
         {
             _clutter.State = ClutterState.Destroyed;
-            Debug.Log(collision.impulse.magnitude);
         }
     }
 

--- a/Assets/Scripts/Possession/Throwable.cs
+++ b/Assets/Scripts/Possession/Throwable.cs
@@ -111,7 +111,7 @@ public class Throwable : MonoBehaviour, IPossessable
 
     private void OnCollisionEnter(Collision collision)
     {
-        if (collision.impulse.magnitude > 0.1f)
+        if (collision.impulse.magnitude > _destroyMinimumImpulse)
         {
             _clutter.State = ClutterState.Destroyed;
         }


### PR DESCRIPTION
## Description
Added the ClutterStates to throwables for interaction with NPCs

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the Possession scene.
2. Press Play.

## Feature Review
#### Added the ClutterStates to throwables for interaction with NPCs. ClutterState.Idle when not moving, ClutterState.Moving while moving, and ClutterState.Destroyed after impact after which it doesnt change state anymore.
Criteria:

- [x] The Throwable has the idle state while not moving
- [x] The Throwable has the moving state while moving
- [x] The Throwable has the destroyed state after colliding with the ground
- [x] Each Throwable has a Clutter script


## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.