### PR TITLE
Fix: Camera Clipping Objects

### DIFF
--- a/Assets/Prefabs/Map.prefab
+++ b/Assets/Prefabs/Map.prefab
@@ -306,7 +306,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CollideAgainst:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 9
   m_IgnoreTag: 
   m_TransparentLayers:
     serializedVersion: 2
@@ -409,7 +409,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CollideAgainst:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 9
   m_IgnoreTag: 
   m_TransparentLayers:
     serializedVersion: 2
@@ -5519,7 +5519,7 @@ Transform:
   m_GameObject: {fileID: 7246120864129021844}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 6.6666665, y: 1.3333333, z: -6.6666665}
+  m_LocalPosition: {x: 6.666666, y: 1.3333331, z: -6.666666}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -5579,7 +5579,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CollideAgainst:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 9
   m_IgnoreTag: 
   m_TransparentLayers:
     serializedVersion: 2
@@ -5682,7 +5682,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CollideAgainst:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 9
   m_IgnoreTag: 
   m_TransparentLayers:
     serializedVersion: 2
@@ -7365,7 +7365,7 @@ Transform:
   m_GameObject: {fileID: 8528138792131412267}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 6.6666675, y: 1.3333333, z: -6.6666665}
+  m_LocalPosition: {x: 6.666667, y: 1.3333331, z: -6.666666}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -7425,7 +7425,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CollideAgainst:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 9
   m_IgnoreTag: 
   m_TransparentLayers:
     serializedVersion: 2
@@ -8512,7 +8512,7 @@ Transform:
   m_GameObject: {fileID: 8977097541369470268}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 6.6666675, y: 1.3333333, z: -6.6666665}
+  m_LocalPosition: {x: 6.666667, y: 1.3333331, z: -6.666666}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -8572,7 +8572,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_CollideAgainst:
     serializedVersion: 2
-    m_Bits: 1
+    m_Bits: 9
   m_IgnoreTag: 
   m_TransparentLayers:
     serializedVersion: 2


### PR DESCRIPTION
## Description
Fixed issues with camera clipping the clutter objects, by updating the map prefab.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open "MVPScene" scene.
2. Press Play.

## Feature Review
#### Testing fixes
Criteria:
- [x] While possessing an object you can not move the camera into another object

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.fixed issues with possessable objects going through the map

Closes #40 