### PR TITLE
unpossess location, player not visible while possessing

### DIFF
--- a/Assets/Scripts/Player/ThirdPersonController.cs
+++ b/Assets/Scripts/Player/ThirdPersonController.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 #if ENABLE_INPUT_SYSTEM 
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
+using UnityEngine.AI;
 #endif
 
 /* Note: animations are called via the controller for both the character and capsule using animator null checks
@@ -92,7 +93,9 @@ namespace StarterAssets
         private Animator _animator;
         private CharacterController _controller;
         private StarterAssetsInputs _input;
+        private PossessionController _posControl;
         private GameObject _mainCamera;
+        private MeshRenderer[] _meshRs;
 
         private const float _threshold = 0.01f;
 
@@ -135,6 +138,9 @@ namespace StarterAssets
             _input = GetComponent<StarterAssetsInputs>();
 #if ENABLE_INPUT_SYSTEM
             _playerInput = GetComponent<PlayerInput>();
+            _posControl = gameObject.GetComponent<PossessionController>();
+            _posControl.CurrentPossessionChanged.AddListener(togglePlayerVisible);
+            _meshRs = gameObject.GetComponentsInChildren<MeshRenderer>();
 #else
 			Debug.LogError( "Starter Assets package is missing dependencies. Please use Tools/Starter Assets/Reinstall Dependencies to fix it");
 #endif
@@ -309,6 +315,17 @@ namespace StarterAssets
             {
                 AudioSource.PlayClipAtPoint(LandingAudioClip, transform.TransformPoint(_controller.center), FootstepAudioVolume);
             }
+        }
+
+        public void toUnpossessLocation()
+        {
+            NavMesh.SamplePosition(_posControl.CurrentPossession.transform.position, out NavMeshHit hit, 3f, 1);
+            _controller.Move(hit.position);
+        }
+
+        public void togglePlayerVisible()
+        {
+            foreach (MeshRenderer mesh in _meshRs) { mesh.enabled = _posControl.CurrentPossession == null; }
         }
     }
 }

--- a/Assets/Scripts/Possession/PossessionController.cs
+++ b/Assets/Scripts/Possession/PossessionController.cs
@@ -52,6 +52,7 @@ public class PossessionController : MonoBehaviour, IObserver
         if (CurrentPossession != null)
         {
             CurrentPossession.GetComponent<IPossessable>().Unpossess();
+            _thirdPersonController.toUnpossessLocation();
             CurrentPossession = null;
             CurrentThrowable = null;
             _thirdPersonController.freeze = false;


### PR DESCRIPTION
## Description
When possessing the player disappears. When unpossessing the player appears near the possessed object.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open "Game" scene.
2. Press Play.

## Feature Review
#### Testing vision controller
Criteria:
- [x] player disappears while possessing
- [x] player reappears when unpossessing
- [x] player appears near possessed object when unpossessing

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.fixed issues with possessable objects going through the map