### PR TITLE
can now unpossess in other room and player correctly moves to new pos…

### DIFF
--- a/Assets/Scripts/Player/ThirdPersonController.cs
+++ b/Assets/Scripts/Player/ThirdPersonController.cs
@@ -321,10 +321,12 @@ namespace StarterAssets
         {
             Ray ray = new Ray(_posControl.CurrentPossession.transform.position, Vector3.down);
             Physics.Raycast(ray, out RaycastHit hitInfo);
+            _controller.enabled = false;
             if (NavMesh.SamplePosition(hitInfo.point, out NavMeshHit hit, 2f, 1))
-            { _controller.Move(hit.position - transform.position); }
+            { this.gameObject.transform.position = hit.position; }
             else if (NavMesh.SamplePosition(hitInfo.point, out hit, 5f, 1))
-            { _controller.Move(hit.position - transform.position); }
+            { this.gameObject.transform.position = hit.position; }
+            _controller.enabled = true;
         }
 
         public void togglePlayerVisible()


### PR DESCRIPTION
## Description
When unpossessing in a different room, the player now moves correctly to the new location. The player used to move against the wall due to moving to the new location with the character controller.


## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Game" scene.
2. Press Play.

## Feature Review
#### Fix Unpossess Location
Criteria:
- [x] When unpossessing with an obstacle in-between (like in a different room), player doesn't get stuck on the obstacle

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.