### PR TITLE
Fix: Player goes through objects

### DIFF
--- a/Assets/Scenes/Mansion.unity
+++ b/Assets/Scenes/Mansion.unity
@@ -8270,7 +8270,7 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 9139403948186476228, guid: 652d3b15a8b620e4f91b6cae1e0ad5de,
         type: 3}
       insertIndex: -1
-      addedObject: {fileID: 302218977}
+      addedObject: {fileID: 302218989}
   m_SourcePrefab: {fileID: 100100000, guid: 652d3b15a8b620e4f91b6cae1e0ad5de, type: 3}
 --- !u!1 &302218976 stripped
 GameObject:
@@ -8278,8 +8278,14 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 302218975}
   m_PrefabAsset: {fileID: 0}
---- !u!64 &302218977
-MeshCollider:
+--- !u!4 &302218988 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7135366488605005744, guid: 652d3b15a8b620e4f91b6cae1e0ad5de,
+    type: 3}
+  m_PrefabInstance: {fileID: 302218975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &302218989
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -8296,16 +8302,9 @@ MeshCollider:
   m_IsTrigger: 0
   m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 2060202397444374319, guid: ed9739dad5bd4b940b8ba2697085b687, type: 3}
---- !u!4 &302218988 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7135366488605005744, guid: 652d3b15a8b620e4f91b6cae1e0ad5de,
-    type: 3}
-  m_PrefabInstance: {fileID: 302218975}
-  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 3
+  m_Size: {x: 0.32402217, y: 0.635164, z: 0.50718564}
+  m_Center: {x: -1.4617963, y: -0.03568229, z: 0.2292591}
 --- !u!1 &304241969 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: d8d21b8a128e402449381e1fa8dfeb52,

--- a/Assets/Scripts/Player/ThirdPersonController.cs
+++ b/Assets/Scripts/Player/ThirdPersonController.cs
@@ -124,9 +124,9 @@ namespace StarterAssets
                 _mainCamera = GameObject.FindGameObjectWithTag("MainCamera");
             }
             int playerLayer = LayerMask.NameToLayer("Player");
-            int observableObjectLayer = LayerMask.NameToLayer("Observable Object");
+            int npcObjectLayer = LayerMask.NameToLayer("Npc");
 
-            Physics.IgnoreLayerCollision(playerLayer, observableObjectLayer);
+            Physics.IgnoreLayerCollision(playerLayer, npcObjectLayer);
         }
 
         private void Start()


### PR DESCRIPTION
## Description
Fixed player goes through objects. Player now only moves through NPC.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Mansion" scene.
2. Press Play.

## Feature Review
#### Ghost Collision
Criteria:
- [ ] The player cannot move through the objects in the scene
- [ ] The player can move through the NPC

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.