### PR TITLE
camera collider fixed for throwables

### DIFF
--- a/Assets/Prefabs/Objects/Throwable/ThrowableBase.prefab
+++ b/Assets/Prefabs/Objects/Throwable/ThrowableBase.prefab
@@ -326,6 +326,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Type: 0
+  _objectPhobia: 3
 --- !u!114 &7906966571320712303
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -587,11 +588,7 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 2070925441746177671, guid: a1a802ecaf6775746bb2a929fb554ad8,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3599072727576389506}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a1a802ecaf6775746bb2a929fb554ad8, type: 3}
 --- !u!114 &7336153797686374626 stripped
 MonoBehaviour:
@@ -599,7 +596,7 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 8751099585421852571}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7336153797686374684}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 45e653bab7fb20e499bda25e1b646fea, type: 3}
@@ -611,39 +608,3 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 8751099585421852571}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &7336153797686374684 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 2070925441746177671, guid: a1a802ecaf6775746bb2a929fb554ad8,
-    type: 3}
-  m_PrefabInstance: {fileID: 8751099585421852571}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &3599072727576389506
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7336153797686374684}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e501d18bb52cf8c40b1853ca4904654f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_CollideAgainst:
-    serializedVersion: 2
-    m_Bits: 1
-  m_IgnoreTag: 
-  m_TransparentLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_MinimumDistanceFromTarget: 0.1
-  m_AvoidObstacles: 1
-  m_DistanceLimit: 0
-  m_MinimumOcclusionTime: 0
-  m_CameraRadius: 0.1
-  m_Strategy: 1
-  m_MaximumEffort: 4
-  m_SmoothingTime: 0
-  m_Damping: 0
-  m_DampingWhenOccluded: 0
-  m_OptimalTargetDistance: 0


### PR DESCRIPTION
## Description
Camera when possessing now also collides with furniture and out of bounds, preventing it from moving into objects and walls.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Mansion" scene.
2. Press Play.

## Feature Review
#### Possession Camera Collider
Criteria:
- [ ] Camera shouldn't move into objects/out of bounds anymore

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.