### PR TITLE
Fix: Camera rotation and movement no longer work during pause.

### DIFF
--- a/Assets/Scripts/Player/ThirdPersonController.cs
+++ b/Assets/Scripts/Player/ThirdPersonController.cs
@@ -153,9 +153,8 @@ namespace StarterAssets
 
         private void Update()
         {
-
             GroundedCheck();
-            if (!freeze)
+            if (!freeze && Time.timeScale > 0)
             {
                 Move();
             }
@@ -163,7 +162,10 @@ namespace StarterAssets
 
         private void LateUpdate()
         {
-            CameraRotation();
+            if(Time.deltaTime > 0)
+            {
+                CameraRotation();
+            }
         }
 
         private void AssignAnimationIDs()


### PR DESCRIPTION
## Description
Camera rotation and movement are now disabled when the game is paused.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Mansion" scene.
2. Press Play.

## Fix Review
#### Camera rotation and movement no longer work during pause
Criteria:
- [x] When pausing, you can no longer move or rotate the camera.

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.