### PR TITLE
fix: disables meshrenderer broken objects

### DIFF
--- a/Assets/Scripts/NPC/Senses/ObservablePhysics.cs
+++ b/Assets/Scripts/NPC/Senses/ObservablePhysics.cs
@@ -60,12 +60,20 @@ public class ObservablePhysics : MonoBehaviour
                 {
                     Destroy(outline);
                 }
-
                 _observableObject.ClearObservers();
+                DestroyObject();
             }
         }
     }
-        
+
+    private void DestroyObject()
+    {
+        if(gameObject.TryGetComponent<MeshRenderer>(out MeshRenderer meshRenderer))
+        {
+            meshRenderer.enabled = false;
+        }
+
+    }
     private void OnCollisionExit(Collision collision)
     {
         if(_observableObject.State == ObjectState.Broken)
@@ -84,6 +92,7 @@ public class ObservablePhysics : MonoBehaviour
     {
         if(_observableObject.State == ObjectState.Broken)
         {
+
             return;
         }
         if (_rigidbody.velocity.magnitude > 0.1f)


### PR DESCRIPTION
## Description
When object gets broken you wont be able to see it

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Mansion" scene.
2. Press Play.

## Feature Review
#### broken item
Criteria:
- [x] objects that are breakable arent visible when broken

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.