### PR TITLE
Fix: pause possession camera

### DIFF
--- a/Assets/Scripts/Possession/ClutterCamera.cs
+++ b/Assets/Scripts/Possession/ClutterCamera.cs
@@ -47,7 +47,10 @@ public class ClutterCamera : MonoBehaviour
     // Update is called once per frame
     private void LateUpdate()
     {
-        CameraRotation();
+        if (Time.deltaTime > 0)
+        {
+            CameraRotation();
+        }
     }
     private void CameraRotation()
     {


### PR DESCRIPTION
## Description
PossessionCamera used to move while the game was paused. Added the same weird if timeDeltatime > 0 that we also used in third person controller to the clutter camera script.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Mansion" scene.
2. Press Play.

## Fix Review
#### Possession Camera
Criteria:
- [x] Can't rotate camera when paused.

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.