### PR TITLE
fix: button mapping now closes on unpause

### DIFF
--- a/Assets/Scenes/Mansion.unity
+++ b/Assets/Scenes/Mansion.unity
@@ -31607,6 +31607,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _backButton: {fileID: 1863154718}
+  _gameManager: {fileID: 1875107164}
 --- !u!1001 &1875107161
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -31716,6 +31717,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9f4bb75d796dee24eb5751e28e039842, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1875107164 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1871557956774806525, guid: a209c4aab6536364e95f4d820d379001,
+    type: 3}
+  m_PrefabInstance: {fileID: 1875107161}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 559d1fce6c551c84488ed86c03073efa, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1877961121

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -2,12 +2,14 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.Audio;
 using UnityEngine.Events;
-using static UnityEngine.Rendering.DebugUI;
 
 public class GameManager : MonoBehaviour
 {
     public delegate void TimeLeftChanged(int value);
     public event TimeLeftChanged OnTimePassedChanged;
+
+    public delegate void PauseToggled(bool isPaused);
+    public event PauseToggled OnPauseToggled;
 
     [HideInInspector] public UnityEvent OnEndGame = new UnityEvent();
 
@@ -50,7 +52,6 @@ public class GameManager : MonoBehaviour
         {
             TogglePause();
         }
-    
     }
 
     private void TogglePause()
@@ -62,6 +63,7 @@ public class GameManager : MonoBehaviour
             _pauseCanvas.SetActive(false);
             Cursor.visible = false;
             Cursor.lockState = CursorLockMode.Locked;
+            OnPauseToggled?.Invoke(false);
         }
         else if (Time.timeScale == 1)
         {
@@ -69,6 +71,7 @@ public class GameManager : MonoBehaviour
             _pauseCanvas.SetActive(true);
             Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;
+            OnPauseToggled?.Invoke(true);
         }
     }
 

--- a/Assets/Scripts/UI/ButtonMappingController.cs
+++ b/Assets/Scripts/UI/ButtonMappingController.cs
@@ -4,13 +4,20 @@ using UnityEngine.UI;
 public class ButtonMappingController : MonoBehaviour
 {
     [SerializeField] private Button _backButton;
+    [SerializeField] private GameManager _gameManager;
 
     private void Awake()
     {
         _backButton.onClick.AddListener(OnBackButtonPressed);
+        _gameManager.OnPauseToggled += OnPauseToggled;
     }
 
     private void OnBackButtonPressed()
+    {
+        gameObject.SetActive(false);
+    }
+
+    private void OnPauseToggled(bool paused)
     {
         gameObject.SetActive(false);
     }

--- a/Assets/Scripts/UI/PauseController.cs
+++ b/Assets/Scripts/UI/PauseController.cs
@@ -1,6 +1,5 @@
 using TMPro;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 
 public class PauseController : MonoBehaviour


### PR DESCRIPTION
## Description
Button mapping now closes on unpause

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Mansion" scene.
2. Press Play.

## Feature Review
#### Button mapping
Criteria:
- [x] pressing escape with button mapping open now closes button mapping and continues game.

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.