### PR TITLE
Fix: Visitor Roam Time

### DIFF
--- a/Assets/Scenes/FinalExam.unity
+++ b/Assets/Scenes/FinalExam.unity
@@ -1599,6 +1599,11 @@ PrefabInstance:
       objectReference: {fileID: 838581764}
     - target: {fileID: 4531111113754646614, guid: 0b19bdcdfd9aa4787988ef8a0c4d7715,
         type: 3}
+      propertyPath: TimeToSpendInRoom
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4531111113754646614, guid: 0b19bdcdfd9aa4787988ef8a0c4d7715,
+        type: 3}
       propertyPath: PanickedTargetLocation
       value: 
       objectReference: {fileID: 54661846}
@@ -5846,6 +5851,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8691210524884891587, guid: 66cbae7a35d4b4c0687916cc2e57a404,
         type: 3}
+      propertyPath: TimeToSpendInRoom
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 8691210524884891587, guid: 66cbae7a35d4b4c0687916cc2e57a404,
+        type: 3}
       propertyPath: PanickedTargetLocation
       value: 
       objectReference: {fileID: 54661846}
@@ -9457,12 +9467,12 @@ PrefabInstance:
     - target: {fileID: 6567433418052461989, guid: 7ae4bea905795274682ac251782c4900,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -3.0973635
+      value: -3.1025681
       objectReference: {fileID: 0}
     - target: {fileID: 6567433418052461989, guid: 7ae4bea905795274682ac251782c4900,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 2.505428
+      value: 2.521042
       objectReference: {fileID: 0}
     - target: {fileID: 6567433418052461989, guid: 7ae4bea905795274682ac251782c4900,
         type: 3}
@@ -19203,6 +19213,11 @@ PrefabInstance:
       propertyPath: CurrentRoom
       value: 
       objectReference: {fileID: 1092526397}
+    - target: {fileID: 4285927498813325517, guid: 6f2fb621035ef43a99591fee797e3c16,
+        type: 3}
+      propertyPath: TimeToSpendInRoom
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 4285927498813325517, guid: 6f2fb621035ef43a99591fee797e3c16,
         type: 3}
       propertyPath: PanickedTargetLocation


### PR DESCRIPTION
## Description
Super short fix
Visitor Roam Time per room has been changed to 30s in the FinalExam Scene

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "FinalExam" scene.
2. Press Play.

## Feature Review
#### Visitor Roam Time
Criteria:
- [x] On all VisitorController's the roam time has been set to 30 seconds

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.