### PR TITLE
Fix: Objects Too Loud

### DIFF
--- a/Assets/Prefabs/Objects/Interactables/Hair Dryer.prefab
+++ b/Assets/Prefabs/Objects/Interactables/Hair Dryer.prefab
@@ -219,7 +219,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 4ee0362bf39d35c4e82016958ece2d7e, type: 3}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.4
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Prefabs/Objects/Interactables/Lawn Mower.prefab
+++ b/Assets/Prefabs/Objects/Interactables/Lawn Mower.prefab
@@ -217,7 +217,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.3
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Prefabs/Objects/Interactables/Oven.prefab
+++ b/Assets/Prefabs/Objects/Interactables/Oven.prefab
@@ -549,7 +549,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.5
   m_Pitch: 1
   Loop: 0
   Mute: 0

--- a/Assets/Scenes/FinalExam.unity
+++ b/Assets/Scenes/FinalExam.unity
@@ -27516,17 +27516,17 @@ PrefabInstance:
     - target: {fileID: 2496963313602622848, guid: 42ae158fb9295ce40a023f776001bc03,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.5
+      value: -0.49885643
       objectReference: {fileID: 0}
     - target: {fileID: 2496963313602622848, guid: 42ae158fb9295ce40a023f776001bc03,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.7
+      value: 0.61311436
       objectReference: {fileID: 0}
     - target: {fileID: 2496963313602622848, guid: 42ae158fb9295ce40a023f776001bc03,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1.05
+      value: -1.0541134
       objectReference: {fileID: 0}
     - target: {fileID: 2496963313602622848, guid: 42ae158fb9295ce40a023f776001bc03,
         type: 3}
@@ -42206,17 +42206,17 @@ PrefabInstance:
     - target: {fileID: 4130052143407715334, guid: 385726608965c994a9b1facfadee75df,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 13.144597
+      value: 13.043422
       objectReference: {fileID: 0}
     - target: {fileID: 4130052143407715334, guid: 385726608965c994a9b1facfadee75df,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.000000029802322
       objectReference: {fileID: 0}
     - target: {fileID: 4130052143407715334, guid: 385726608965c994a9b1facfadee75df,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -8.790085
+      value: -8.689849
       objectReference: {fileID: 0}
     - target: {fileID: 4130052143407715334, guid: 385726608965c994a9b1facfadee75df,
         type: 3}
@@ -58642,17 +58642,17 @@ PrefabInstance:
     - target: {fileID: 4774150348840184391, guid: f8edf595e91b2c143b84dd2047dea3e0,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.173113
+      value: 5.191688
       objectReference: {fileID: 0}
     - target: {fileID: 4774150348840184391, guid: f8edf595e91b2c143b84dd2047dea3e0,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.8000001
+      value: 1.809
       objectReference: {fileID: 0}
     - target: {fileID: 4774150348840184391, guid: f8edf595e91b2c143b84dd2047dea3e0,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.8009231
+      value: -0.8007823
       objectReference: {fileID: 0}
     - target: {fileID: 4774150348840184391, guid: f8edf595e91b2c143b84dd2047dea3e0,
         type: 3}

--- a/Assets/Sounds/Interactables/Hair Dryer/hairdryer_running.wav.meta
+++ b/Assets/Sounds/Interactables/Hair Dryer/hairdryer_running.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Sounds/Interactables/Lawnmower-rattling.mp3.meta
+++ b/Assets/Sounds/Interactables/Lawnmower-rattling.mp3.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Sounds/Interactables/Microwave/Microwave-humming.mp3.meta
+++ b/Assets/Sounds/Interactables/Microwave/Microwave-humming.mp3.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Sounds/Interactables/Teapot/teapot_boiling.wav.meta
+++ b/Assets/Sounds/Interactables/Teapot/teapot_boiling.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Sounds/Interactables/Timer/timer_ticking.wav.meta
+++ b/Assets/Sounds/Interactables/Timer/timer_ticking.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Sounds/Interactables/gramophone.wav.meta
+++ b/Assets/Sounds/Interactables/gramophone.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Sounds/Interactables/tv-static.wav.meta
+++ b/Assets/Sounds/Interactables/tv-static.wav.meta
@@ -5,7 +5,7 @@ AudioImporter:
   serializedVersion: 7
   defaultSettings:
     serializedVersion: 2
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1


### PR DESCRIPTION
## Description
Some objects are less loud now.
Also fixed stuttering when interacting with objects with long sound clips (e.g. Grammophone)

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "FinalExam" scene.
2. Press Play.

## Feature Review
#### Console and Cheats
The objects that are no longer too loud:
- [x] Oven (Kitchen)
- [x] Hair Dryer (Bathroom)
- [x] Lawn Mower (Courtyard)
- [x] No more freezing when interacting with grammophone (Living Room)


## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.