### PR TITLE
Change: Quit Level

### DIFF
--- a/Assets/Prefabs/UI/Full UI/Quit Confirmation Canvas.prefab
+++ b/Assets/Prefabs/UI/Full UI/Quit Confirmation Canvas.prefab
@@ -216,7 +216,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_text: Are you sure you want to quit this level? You lose all the progres you
-    made and will be taken back to the main menu.
+    made and will be taken back to the level select screen.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4e537a56d3fec8c41ba31784d7a4d9af, type: 2}
   m_sharedMaterial: {fileID: -8530696936359007190, guid: 4e537a56d3fec8c41ba31784d7a4d9af,
@@ -1361,4 +1361,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _confirmButton: {fileID: 516680725972974329}
   _cancelButton: {fileID: 5697451360867712337}
-  _mainMenuSceneName: MainMenuUI
+  _mainMenuSceneName: LevelSelectUI

--- a/Assets/Prefabs/UI/Pause Canvas.prefab
+++ b/Assets/Prefabs/UI/Pause Canvas.prefab
@@ -404,7 +404,7 @@ GameObject:
   - component: {fileID: 7981848072705094136}
   - component: {fileID: 1980324258929639412}
   m_Layer: 5
-  m_Name: Button Main menu
+  m_Name: Button Quit Level
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -531,7 +531,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &7078945592317952038
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1276,7 +1276,7 @@ GameObject:
   - component: {fileID: 3770903563247134657}
   - component: {fileID: 1139996103832001467}
   m_Layer: 5
-  m_Name: Main menu
+  m_Name: Quit Level
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1329,7 +1329,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Main menu
+  m_text: 'Quit level
 
 
 '


### PR DESCRIPTION
## Description
Changed Main Menu Button to Quit Level Button and it now goes back to Level Select Screen

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "FinalExam" scene.
2. Press Play.

## Change Review
#### Realtor model
Criteria:
- [x] Quit Level Button on Options still opens Confirmation Popup
- [x] Confirming confirmation popup takes you back to level select
- [x] Text on confirmation popup now says it will take you back to level select

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.