### PR TITLE
Fix/pause devmenu npc overlay

### DIFF
--- a/Assets/Prefabs/NPCs/Pause menu overlays/Visitor Pause Jacen Variant.prefab
+++ b/Assets/Prefabs/NPCs/Pause menu overlays/Visitor Pause Jacen Variant.prefab
@@ -8,6 +8,12 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1452131382651339751, guid: fb749535c83bb01479558fbb1a50f340,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b2d59176a7e398a4496fd257251f744a,
+        type: 3}
     - target: {fileID: 1564665377593265591, guid: fb749535c83bb01479558fbb1a50f340,
         type: 3}
       propertyPath: m_Name
@@ -169,6 +175,12 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7497025663163319890, guid: fb749535c83bb01479558fbb1a50f340,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 42da437f4d85a46479e4b6cbefe5aa50,
+        type: 3}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Prefabs/NPCs/Pause menu overlays/Visitor Pause Robin Variant.prefab
+++ b/Assets/Prefabs/NPCs/Pause menu overlays/Visitor Pause Robin Variant.prefab
@@ -8,6 +8,12 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 497297600230708200, guid: 2e4e1638ec5949d49bf21631473650a9,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: a457552c7039e164db93b615c05a8a9e,
+        type: 3}
     - target: {fileID: 2334502159735116667, guid: 2e4e1638ec5949d49bf21631473650a9,
         type: 3}
       propertyPath: m_text
@@ -158,6 +164,12 @@ PrefabInstance:
       propertyPath: _investigateFace
       value: 
       objectReference: {fileID: 21300000, guid: 3ce1a659d1c9749ffb1586fc44314a34,
+        type: 3}
+    - target: {fileID: 8848176177258485341, guid: 2e4e1638ec5949d49bf21631473650a9,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: ce6c142fa8c3d3c45a13d161b1d785dc,
         type: 3}
     - target: {fileID: 8888634827285010445, guid: 2e4e1638ec5949d49bf21631473650a9,
         type: 3}


### PR DESCRIPTION
## Description
npc overlay in pause menu now looks correct

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "FinalExam" scene.
2. Press Play.

## Fix Review
#### Npc overlay
Criteria:
- [x] Filler and lineart in pause menu are no longer from wrong person
![image](https://github.com/ApericotStudio/Poltergeist/assets/50752585/d13185b3-b77a-4776-a0dd-c6f76597a525)


## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.