### PR TITLE
Fix: Sensitivity not updating

### DIFF
--- a/Assets/Scenes/FinalExam.unity
+++ b/Assets/Scenes/FinalExam.unity
@@ -19086,6 +19086,11 @@ PrefabInstance:
       propertyPath: _backCanvas
       value: 
       objectReference: {fileID: 843652852}
+    - target: {fileID: 2113787922176600196, guid: 9dbbfc3e03e53934793180b1669667cf,
+        type: 3}
+      propertyPath: _thirdPersonController
+      value: 
+      objectReference: {fileID: 1724966205}
     - target: {fileID: 3753961809939355021, guid: 9dbbfc3e03e53934793180b1669667cf,
         type: 3}
       propertyPath: m_Name
@@ -26100,7 +26105,7 @@ PrefabInstance:
     - target: {fileID: 8522012494151237017, guid: c47129383c31e2d4eaeef471d8a277e4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.28571445
+      value: 0.28571442
       objectReference: {fileID: 0}
     - target: {fileID: 8522012494151237017, guid: c47129383c31e2d4eaeef471d8a277e4,
         type: 3}

--- a/Assets/Scripts/UI/OptionsController.cs
+++ b/Assets/Scripts/UI/OptionsController.cs
@@ -1,3 +1,4 @@
+using StarterAssets;
 using UnityEngine;
 using UnityEngine.Audio;
 using UnityEngine.UI;
@@ -29,6 +30,10 @@ public class OptionsController : MonoBehaviour
     [Tooltip("Canvas that is opened when back button is pressed")]
     [SerializeField] private GameObject _backCanvas;
     [SerializeField] private AudioMixer _audioMixer;
+
+    [Header("Player References")]
+    [Tooltip("The player in the game")]
+    [SerializeField] private ThirdPersonController _thirdPersonController;
 
     private void Awake()
     {
@@ -83,6 +88,7 @@ public class OptionsController : MonoBehaviour
 
     private void OnSensitivitySliderValueChanged(float value)
     {
+        _thirdPersonController.SetSensitivity(value);
         PlayerPrefs.SetFloat(PlayerPrefsVariable.Sensitivity.ToString(), value);
         PlayerPrefs.Save();
     }


### PR DESCRIPTION
## Description
Sensitivity was not updating in-game only at start of levels. This PR fixes that

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "FinalExam" scene.
2. Press Play.

## Fix Review
Criteria:
- [x] Updating Sensitivity in pause menu in-game actually updates sensitivity

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.