### PR TITLE
Fixed hitpoint on throwables

### DIFF
--- a/Assets/Scripts/Possession/Throwable.cs
+++ b/Assets/Scripts/Possession/Throwable.cs
@@ -80,6 +80,7 @@ public class Throwable : MonoBehaviour, IPossessable, IObserver
         StartCoroutine(_cameraScript.ResetCamera());
         _cameraScript.LockCameraPosition = true;
         _lineRenderer.enabled = false;
+        _hitPointImage.gameObject.SetActive(false);
         Possessed = false;
     }
 
@@ -88,6 +89,7 @@ public class Throwable : MonoBehaviour, IPossessable, IObserver
         if(_observableObject.State == ObjectState.Idle)
         {
             _rb.AddForce(_aim * _throwForce, ForceMode.Impulse);
+            _hitPointImage.gameObject.SetActive(false);
         }        
     }
 
@@ -117,10 +119,12 @@ public class Throwable : MonoBehaviour, IPossessable, IObserver
                 LineRenderer.SetPosition(i, hit.point);
                 LineRenderer.positionCount = i + 1;
                 _hitPointImage.position = hit.point + hit.normal * 0.01f;
-                _hitPointImage.transform.up = hit.normal;                
+                _hitPointImage.transform.up = hit.normal;
+                _hitPointImage.gameObject.SetActive(true);
                 return;
             }
         }
+        _hitPointImage.gameObject.SetActive(true);
         _hitPointImage.position = LineRenderer.GetPosition(i);
     }
 


### PR DESCRIPTION
## Description
Hitpoint image is now shown at the end of the throwing arc trajectory

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "FinalExam" scene.
2. Press Play.

## Fix Review
Criteria:
- [x] When aiming with a throwable the hitpoint is shown at the end of the trajectory

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.