### PR TITLE
Fix: Ghost Face Visibility

### DIFF
--- a/Assets/Scripts/Player/ThirdPersonController.cs
+++ b/Assets/Scripts/Player/ThirdPersonController.cs
@@ -100,7 +100,8 @@ namespace StarterAssets
         private StarterAssetsInputs _input;
         private PossessionController _posControl;
         private GameObject _mainCamera;
-        private SkinnedMeshRenderer[] _meshRs;
+        private SkinnedMeshRenderer[] _skinnedMeshRs;
+        private MeshRenderer[] _meshRs;
 
         private const float _threshold = 0.01f;
 
@@ -163,7 +164,8 @@ namespace StarterAssets
             _playerInput = GetComponent<PlayerInput>();
             _posControl = gameObject.GetComponent<PossessionController>();
             _posControl.CurrentPossessionChanged.AddListener(TogglePlayerVisible);
-            _meshRs = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
+            _skinnedMeshRs = gameObject.GetComponentsInChildren<SkinnedMeshRenderer>();
+            _meshRs = gameObject.GetComponentsInChildren<MeshRenderer>();
 #else
 			Debug.LogError( "Starter Assets package is missing dependencies. Please use Tools/Starter Assets/Reinstall Dependencies to fix it");
 #endif
@@ -352,7 +354,9 @@ namespace StarterAssets
 
         public void TogglePlayerVisible()
         {
-            foreach (SkinnedMeshRenderer mesh in _meshRs) { mesh.enabled = _posControl.CurrentPossession == null; }
+            bool visible = _posControl.CurrentPossession == null;
+            foreach (SkinnedMeshRenderer mesh in _skinnedMeshRs) { mesh.enabled = visible; }
+            foreach (MeshRenderer mesh in _meshRs) { mesh.enabled = visible; }
         }
     }
 }


### PR DESCRIPTION
## Description
Fixed ghost face staying visible while possessing by also disabling all MeshRenderers on player object, instead of only disabling skinned meshrenderers.

## Fix Review
Criteria:
- [x] Ghost Face disappears when possessing

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.