### PR TITLE
Fix: Tutorial Text

### DIFF
--- a/Assets/Scripts/UI/Utility/Tutorial Test 1.asset
+++ b/Assets/Scripts/UI/Utility/Tutorial Test 1.asset
@@ -13,9 +13,9 @@ MonoBehaviour:
   m_Name: Tutorial Test 1
   m_EditorClassIdentifier: 
   Title: Movement
-  Description: You can <font="Underdog-Regular SDF">fly around</font> using <font="Underdog-Regular
+  Description: 'You can <font="Underdog-Regular SDF">fly around</font> using <font="Underdog-Regular
     SDF"><b>WASD</b></font> and your mouse to look around. You <b>move towards wherever
-    you're looking<font="Underdog-Regular SDF"</b> using W.</font><br><br>You can
+    you''re looking<font="Underdog-Regular SDF"></b> using W.</font><br><br>You can
     also <font="Underdog-Regular SDF">fly up and down</font> using <font="Underdog-Regular
     SDF"><b>Spacebar (up)</b> and <b>Shift (down)</b></font>.<br><br>Fly towards
-    the living room.
+    the living room. '


### PR DESCRIPTION
## Description
A missing closing bracket for the html has been added back in

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes/UI and open the "Assignment" scene.
2. Press Play.

## Feat Review
#### Tutorial Text
Criteria:
- [ ] No more missing closing brackets

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.