### PR TITLE
Fix: Level Select Grades

### DIFF
--- a/Assets/Prefabs/Killcam/Killcam.prefab
+++ b/Assets/Prefabs/Killcam/Killcam.prefab
@@ -11,7 +11,6 @@ GameObject:
   - component: {fileID: 8416540820460392027}
   - component: {fileID: 2274965528635729830}
   - component: {fileID: 5348048142059726201}
-  - component: {fileID: 4061987694037499571}
   m_Layer: 0
   m_Name: Killcam
   m_TagString: Untagged
@@ -129,19 +128,3 @@ MonoBehaviour:
     mipBias: 0
     varianceClampScale: 0.9
     contrastAdaptiveSharpening: 0
---- !u!114 &4061987694037499571
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4505307101366651181}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 85c65b1dd858422428e77e09068750b3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _scareCamImage: {fileID: 0}
-  _visitorCollection: {fileID: 0}
-  _cameraOffset: {x: 0, y: 0, z: 1}
-  _followDuration: 2

--- a/Assets/Prefabs/Scene/Game Managers.prefab
+++ b/Assets/Prefabs/Scene/Game Managers.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 3028869041759280478}
   - component: {fileID: 7444451536167477588}
   - component: {fileID: 6550857201775457575}
+  - component: {fileID: 1729944933779970553}
   m_Layer: 0
   m_Name: Game Managers
   m_TagString: Untagged
@@ -112,3 +113,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _playerController: {fileID: 0}
   _uiController: {fileID: 0}
+--- !u!114 &1729944933779970553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1148388120156649140}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85c65b1dd858422428e77e09068750b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _scareCam: {fileID: 0}
+  _scareCamImage: {fileID: 0}
+  _visitorCollection: {fileID: 0}
+  _cameraOffset: {x: 0, y: 0, z: 1}
+  _followDuration: 3

--- a/Assets/Scenes/Assignment.unity
+++ b/Assets/Scenes/Assignment.unity
@@ -51544,6 +51544,12 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 44666c2ccb5557f43b3aec70da29c3ab, type: 3}
+--- !u!20 &1699548303 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 2274965528635729830, guid: 44666c2ccb5557f43b3aec70da29c3ab,
+    type: 3}
+  m_PrefabInstance: {fileID: 1699548302}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1701805875
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -56243,6 +56249,21 @@ PrefabInstance:
       propertyPath: m_Name
       value: Game Managers
       objectReference: {fileID: 0}
+    - target: {fileID: 1729944933779970553, guid: a209c4aab6536364e95f4d820d379001,
+        type: 3}
+      propertyPath: _scareCam
+      value: 
+      objectReference: {fileID: 1699548303}
+    - target: {fileID: 1729944933779970553, guid: a209c4aab6536364e95f4d820d379001,
+        type: 3}
+      propertyPath: _scareCamImage
+      value: 
+      objectReference: {fileID: 1236138637}
+    - target: {fileID: 1729944933779970553, guid: a209c4aab6536364e95f4d820d379001,
+        type: 3}
+      propertyPath: _visitorCollection
+      value: 
+      objectReference: {fileID: 1207009365}
     - target: {fileID: 1871557956774806525, guid: a209c4aab6536364e95f4d820d379001,
         type: 3}
       propertyPath: _audioMixer

--- a/Assets/Scenes/FinalExam.unity
+++ b/Assets/Scenes/FinalExam.unity
@@ -49866,8 +49866,7 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 4061987694037499571, guid: 44666c2ccb5557f43b3aec70da29c3ab, type: 3}
+    m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
@@ -54451,6 +54450,21 @@ PrefabInstance:
       propertyPath: m_Name
       value: Game Managers
       objectReference: {fileID: 0}
+    - target: {fileID: 1729944933779970553, guid: a209c4aab6536364e95f4d820d379001,
+        type: 3}
+      propertyPath: _scareCam
+      value: 
+      objectReference: {fileID: 1699548303}
+    - target: {fileID: 1729944933779970553, guid: a209c4aab6536364e95f4d820d379001,
+        type: 3}
+      propertyPath: _scareCamImage
+      value: 
+      objectReference: {fileID: 1236138637}
+    - target: {fileID: 1729944933779970553, guid: a209c4aab6536364e95f4d820d379001,
+        type: 3}
+      propertyPath: _visitorCollection
+      value: 
+      objectReference: {fileID: 1207009365}
     - target: {fileID: 1871557956774806525, guid: a209c4aab6536364e95f4d820d379001,
         type: 3}
       propertyPath: _audioMixer
@@ -54495,11 +54509,7 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 1148388120156649140, guid: a209c4aab6536364e95f4d820d379001,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1875107164}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a209c4aab6536364e95f4d820d379001, type: 3}
 --- !u!114 &1875107162 stripped
 MonoBehaviour:
@@ -54507,35 +54517,12 @@ MonoBehaviour:
     type: 3}
   m_PrefabInstance: {fileID: 1875107161}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1875107163}
+  m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9f4bb75d796dee24eb5751e28e039842, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &1875107163 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1148388120156649140, guid: a209c4aab6536364e95f4d820d379001,
-    type: 3}
-  m_PrefabInstance: {fileID: 1875107161}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1875107164
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1875107163}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 85c65b1dd858422428e77e09068750b3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _scareCam: {fileID: 1699548303}
-  _scareCamImage: {fileID: 1236138637}
-  _visitorCollection: {fileID: 1207009365}
-  _cameraOffset: {x: 0, y: 0, z: 1}
-  _followDuration: 3
 --- !u!1 &1877957567
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Game/Grade.cs
+++ b/Assets/Scripts/Game/Grade.cs
@@ -8,29 +8,12 @@ public class Grade
 
     public Grade(GradeFile gradeFile)
     {
+        _result = gradeFile.Result;
+        _isResultCalculated = true;
         VisitorsLeft = gradeFile.VisitorsLeft;
         DifferentObjectsUsed = gradeFile.DifferentObjectsUsed;
         PhobiaScares = gradeFile.PhobiaScares;
         TimePassed = gradeFile.TimePassed;
-
-        // Get grading from file
-        GradeObjects = ScriptableObject.CreateInstance<GradeCriteria>();
-        GradeObjects.Criteria_A = gradeFile.ObjectsCriteria[0];
-        GradeObjects.Criteria_B = gradeFile.ObjectsCriteria[1];
-        GradeObjects.Criteria_C = gradeFile.ObjectsCriteria[2];
-
-        GradeTime = ScriptableObject.CreateInstance<GradeCriteria>();
-        GradeTime.Criteria_A = gradeFile.TimeCriteria[0];
-        GradeTime.Criteria_B = gradeFile.TimeCriteria[1];
-        GradeTime.Criteria_C = gradeFile.TimeCriteria[2];
-
-        if(gradeFile.PhobiasCriteria != null && gradeFile.PhobiasCriteria.Count == 3)
-        {
-            GradePhobias = ScriptableObject.CreateInstance<GradeCriteria>();
-            GradePhobias.Criteria_A = gradeFile.PhobiasCriteria[0];
-            GradePhobias.Criteria_B = gradeFile.PhobiasCriteria[1];
-            GradePhobias.Criteria_C = gradeFile.PhobiasCriteria[2];
-        }
     }
 
     public Grade()
@@ -38,16 +21,16 @@ public class Grade
 
     }
 
-    private bool _isDirty = true;
+    private bool _isResultCalculated = false;
     private int _result;
     public int Result
     {
         get
         {
-            if (_isDirty)
+            if (!_isResultCalculated)
             {
                 _result = CalculateResult();
-                _isDirty = false;
+                _isResultCalculated = false;
             }
             return _result;
         }
@@ -67,7 +50,6 @@ public class Grade
         set
         {
             _visitorsLeft = value;
-            _isDirty = true;
         }
     }
     public int DifferentObjectsUsed
@@ -79,7 +61,6 @@ public class Grade
         set
         {
             _differentObjectsUsed = value;
-            _isDirty = true;
         }
     }
     public int PhobiaScares
@@ -91,7 +72,6 @@ public class Grade
         set
         {
             _phobiaScares = value;
-            _isDirty = true;
         }
     }
     public int TimePassed
@@ -103,7 +83,6 @@ public class Grade
         set
         {
             _timePassed = value;
-            _isDirty = true;
         }
     }
 

--- a/Assets/Scripts/Game/Grade.cs
+++ b/Assets/Scripts/Game/Grade.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 public class Grade
 {
     public GradeCriteria GradeObjects;
@@ -10,17 +12,24 @@ public class Grade
         DifferentObjectsUsed = gradeFile.DifferentObjectsUsed;
         PhobiaScares = gradeFile.PhobiaScares;
         TimePassed = gradeFile.TimePassed;
-        switch (gradeFile.GradeCriterias.Count)
+
+        // Get grading from file
+        GradeObjects = ScriptableObject.CreateInstance<GradeCriteria>();
+        GradeObjects.Criteria_A = gradeFile.ObjectsCriteria[0];
+        GradeObjects.Criteria_B = gradeFile.ObjectsCriteria[1];
+        GradeObjects.Criteria_C = gradeFile.ObjectsCriteria[2];
+
+        GradeTime = ScriptableObject.CreateInstance<GradeCriteria>();
+        GradeTime.Criteria_A = gradeFile.TimeCriteria[0];
+        GradeTime.Criteria_B = gradeFile.TimeCriteria[1];
+        GradeTime.Criteria_C = gradeFile.TimeCriteria[2];
+
+        if(gradeFile.PhobiasCriteria != null && gradeFile.PhobiasCriteria.Count == 3)
         {
-            case 2:
-                GradeObjects = gradeFile.GradeCriterias[0];
-                GradeTime = gradeFile.GradeCriterias[1];
-                break;
-            case 3:
-                GradeObjects = gradeFile.GradeCriterias[0];
-                GradePhobias = gradeFile.GradeCriterias[1];
-                GradeTime = gradeFile.GradeCriterias[2];
-                break;
+            GradePhobias = ScriptableObject.CreateInstance<GradeCriteria>();
+            GradePhobias.Criteria_A = gradeFile.PhobiasCriteria[0];
+            GradePhobias.Criteria_B = gradeFile.PhobiasCriteria[1];
+            GradePhobias.Criteria_C = gradeFile.PhobiasCriteria[2];
         }
     }
 

--- a/Assets/Scripts/Game/GradeFile.cs
+++ b/Assets/Scripts/Game/GradeFile.cs
@@ -9,7 +9,19 @@ public class GradeFile
         DifferentObjectsUsed = differentObjectsUsed;
         PhobiaScares = 0;
         TimePassed = timePassed;
-        GradeCriterias = gradeCriterias;
+        switch(gradeCriterias.Count)
+        {
+            case 2:
+                ObjectsCriteria = new List<float> { gradeCriterias[0].Criteria_A, gradeCriterias[0].Criteria_B, gradeCriterias[0].Criteria_C };
+                TimeCriteria = new List<float> { gradeCriterias[1].Criteria_A, gradeCriterias[1].Criteria_B, gradeCriterias[1].Criteria_C };
+                break;
+            case 3:
+                ObjectsCriteria = new List<float> { gradeCriterias[0].Criteria_A, gradeCriterias[0].Criteria_B, gradeCriterias[0].Criteria_C };
+                PhobiasCriteria = new List<float> { gradeCriterias[1].Criteria_A, gradeCriterias[1].Criteria_B, gradeCriterias[1].Criteria_C };
+                TimeCriteria = new List<float> { gradeCriterias[2].Criteria_A, gradeCriterias[2].Criteria_B, gradeCriterias[2].Criteria_C };
+                break;
+
+        }
     }
 
     public int Result;
@@ -18,5 +30,7 @@ public class GradeFile
     public int PhobiaScares;
     public int TimePassed;
 
-    public List<GradeCriteria> GradeCriterias;
+    public List<float> ObjectsCriteria;
+    public List<float> PhobiasCriteria;
+    public List<float> TimeCriteria;
 }

--- a/Assets/Scripts/Game/GradeFile.cs
+++ b/Assets/Scripts/Game/GradeFile.cs
@@ -2,26 +2,13 @@ using System.Collections.Generic;
 
 public class GradeFile
 {
-    public GradeFile(int result, int visitorsLeft, int differentObjectsUsed, int timePassed, List<GradeCriteria> gradeCriterias)
+    public GradeFile(int result, int visitorsLeft, int differentObjectsUsed, int phobiaScares, int timePassed)
     {
         Result = result;
         VisitorsLeft = visitorsLeft;
         DifferentObjectsUsed = differentObjectsUsed;
-        PhobiaScares = 0;
+        PhobiaScares = phobiaScares;
         TimePassed = timePassed;
-        switch(gradeCriterias.Count)
-        {
-            case 2:
-                ObjectsCriteria = new List<float> { gradeCriterias[0].Criteria_A, gradeCriterias[0].Criteria_B, gradeCriterias[0].Criteria_C };
-                TimeCriteria = new List<float> { gradeCriterias[1].Criteria_A, gradeCriterias[1].Criteria_B, gradeCriterias[1].Criteria_C };
-                break;
-            case 3:
-                ObjectsCriteria = new List<float> { gradeCriterias[0].Criteria_A, gradeCriterias[0].Criteria_B, gradeCriterias[0].Criteria_C };
-                PhobiasCriteria = new List<float> { gradeCriterias[1].Criteria_A, gradeCriterias[1].Criteria_B, gradeCriterias[1].Criteria_C };
-                TimeCriteria = new List<float> { gradeCriterias[2].Criteria_A, gradeCriterias[2].Criteria_B, gradeCriterias[2].Criteria_C };
-                break;
-
-        }
     }
 
     public int Result;
@@ -29,8 +16,4 @@ public class GradeFile
     public int DifferentObjectsUsed;
     public int PhobiaScares;
     public int TimePassed;
-
-    public List<float> ObjectsCriteria;
-    public List<float> PhobiasCriteria;
-    public List<float> TimeCriteria;
 }

--- a/Assets/Scripts/Game/LevelGradeHandler.cs
+++ b/Assets/Scripts/Game/LevelGradeHandler.cs
@@ -37,13 +37,6 @@ public class LevelGradeHandler
     public void Save(Grade grade, string sceneName)
     {
         string fullPath = Path.Combine(_gradeDirPath, sceneName);
-        
-        List<GradeCriteria> gradeCriterias = new List<GradeCriteria>();
-        gradeCriterias.Add(grade.GradeObjects);
-        if (grade.GradePhobias != null) gradeCriterias.Add(grade.GradePhobias);
-        gradeCriterias.Add(grade.GradeTime);
-
-
         GradeFile gradeToStore = new GradeFile(grade.Result, grade.VisitorsLeft, grade.DifferentObjectsUsed, grade.PhobiaScares, grade.TimePassed);
         try
         {

--- a/Assets/Scripts/Game/LevelGradeHandler.cs
+++ b/Assets/Scripts/Game/LevelGradeHandler.cs
@@ -44,7 +44,7 @@ public class LevelGradeHandler
         gradeCriterias.Add(grade.GradeTime);
 
 
-        GradeFile gradeToStore = new GradeFile(grade.Result, grade.VisitorsLeft, grade.DifferentObjectsUsed, (int)grade.TimePassed, gradeCriterias);
+        GradeFile gradeToStore = new GradeFile(grade.Result, grade.VisitorsLeft, grade.DifferentObjectsUsed, grade.PhobiaScares, grade.TimePassed);
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(fullPath));


### PR DESCRIPTION
## Description
Updated the gradefile script to save the criteria that were used to calculate the grade in the grade file as well. Due to a recent update these criteria are needed to calculate the actual grade a player got. 

UPDATE: I was being dumb, the resulting grade is obviously already stored in the grade file so when you load it in there is absolutely no need to calculate it again. So now when a grade file is loaded a boolean that indicates whether the grade has already been calculated will be set to true. If it is it will skip the calculation that caused the error in the first place.

The extra bonus with this solution is the fact the absolutely nothing has to be changed about the structure of the grade file so old save files will still work

Also applied the changes to the Scare Cam to the prefabs which is something i forgot to do before

## Setting up testing environment
1. Clear your PlayerPrefs and remove "Assignment" and "FinalExam" files from C:\Users\"YOUR USERNAME HERE"\AppData\LocalLow\Apericot Studio\Manor Madness (if they exist)
2. In the project window navigate to Project/Assets/Scenes/UI and open the "Level Select" scene.
3. Press Play.

## Feat Review
#### Level Select Grades
Criteria:
- [x] The level grading still works the same
- [x] The level grading doesn't break on old save files
- [x] The amount of phobias are now also saved in the save file

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.