### PR TITLE
Fix: Audio not playing

### DIFF
--- a/Assets/Scripts/UI/QuitConfirmationController.cs
+++ b/Assets/Scripts/UI/QuitConfirmationController.cs
@@ -25,6 +25,7 @@ public class QuitConfirmationController : MonoBehaviour
     private void OnConfirmButtonPressed()
     {
         Time.timeScale = 1;
+        AudioListener.pause = false;
         SceneManager.LoadScene(_mainMenuSceneName);
     }
 


### PR DESCRIPTION
When you quit a level, the main menu theme wouldnt play.
That was because in order to pause the audio in the pause screen we set the AudioListener.Pause = true. But this persists between scenes so the fix was simply to disable pause when you quit the level from the pause menu