### PR TITLE
Fix: Visitors breaking their back

### DIFF
--- a/Assets/Scripts/NPC/States/RoamState.cs
+++ b/Assets/Scripts/NPC/States/RoamState.cs
@@ -31,6 +31,7 @@ public class RoamState : IState
         {
             Transform inspectTarget = _visitorController.CurrentRoom.GetRandomInspectableObject(_visitorController.InspectTarget);
             _visitorController.InspectTarget = inspectTarget;
+            _visitorController.LookAt(inspectTarget);
             Vector3 newRoamLocation = GetClosestLocationToInspectTarget();
             _visitorController.Agent.SetDestination(newRoamLocation);
             yield return new WaitUntil(() => _visitorController.Agent.remainingDistance < 1f && !_visitorController.Agent.pathPending && IsRoaming());

--- a/Assets/Videos/FinalCutscene.mp4.meta
+++ b/Assets/Videos/FinalCutscene.mp4.meta
@@ -12,7 +12,25 @@ VideoClipImporter:
   flipVertical: 0
   flipHorizontal: 0
   importAudio: 1
-  targetSettings: {}
+  targetSettings:
+    0:
+      enableTranscoding: 1
+      codec: 0
+      resizeFormat: 0
+      aspectRatio: 0
+      customWidth: 2560
+      customHeight: 1440
+      bitrateMode: 2
+      spatialQuality: 2
+    1:
+      enableTranscoding: 1
+      codec: 0
+      resizeFormat: 0
+      aspectRatio: 0
+      customWidth: 2560
+      customHeight: 1440
+      bitrateMode: 2
+      spatialQuality: 2
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -14,6 +14,7 @@
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.5",
     "com.unity.toolchain.linux-x86_64": "2.0.6",
+    "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.6",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -194,6 +194,16 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.toolchain.win-x86_64-linux-x86_64": {
+      "version": "2.0.6",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.7",
+        "com.unity.sysroot.linux-x86_64": "2.0.6"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ugui": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
It's still there a little bit, but it's way less then before. The issue was a missing call to LookAt before a visitor walks over to the next object, so they will continue looking at the old object