### PR TITLE
Fix: Console After First level

### DIFF
--- a/Assets/Scripts/Game/Console/DeveloperConsoleBehaviour.cs
+++ b/Assets/Scripts/Game/Console/DeveloperConsoleBehaviour.cs
@@ -15,8 +15,6 @@ public class DeveloperConsoleBehaviour : MonoBehaviour
 
     private float _pausedTimeScale;
 
-    private static DeveloperConsoleBehaviour _instance;
-
     private DeveloperConsole _developerConsole;
 
     public DeveloperConsole DeveloperConsole
@@ -26,19 +24,6 @@ public class DeveloperConsoleBehaviour : MonoBehaviour
             if (_developerConsole != null) { return _developerConsole; }
             return _developerConsole = new DeveloperConsole(_prefix, _commands);
         }
-    }
-
-    private void Awake()
-    {
-        if (_instance != null && _instance != this)
-        {
-            Destroy(gameObject);
-            return;
-        }
-
-        _instance = this;
-
-        DontDestroyOnLoad(gameObject);
     }
 
     public void Toggle()


### PR DESCRIPTION
## Description
Dev console script had dontdestroyonload, which caused the reference to this console to be missing if you play another level after the first. Removed Dontdestroyonload from developerconsolebehaviour script.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes/UI and open the "Assignment" or "Final Exam" scene.
2. Press Play.
3. Open the console and try a command
4. Quit the level and go to level select
5. Select a level
6. Try the console again

## Fix Review
#### Developer Console in second level
Criteria:
- [ ] Developer console still works after the first level you play.

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.