### PR TITLE
Fix: Realtor doesn't stay near visitor

### DIFF
--- a/Assets/Prefabs/NPCs/NPCFelicia.prefab
+++ b/Assets/Prefabs/NPCs/NPCFelicia.prefab
@@ -5331,7 +5331,7 @@ NavMeshAgent:
   m_Radius: 0.5
   m_Speed: 2
   m_Acceleration: 10
-  avoidancePriority: 40
+  avoidancePriority: 10
   m_AngularSpeed: 200
   m_StoppingDistance: 0
   m_AutoTraverseOffMeshLink: 1
@@ -5364,6 +5364,9 @@ MonoBehaviour:
   PanickedSpeed: 5.335
   _fearValue: 0
   OnFearValueChange:
+    m_PersistentCalls:
+      m_Calls: []
+  OnSoothe:
     m_PersistentCalls:
       m_Calls: []
   VisitorPhobia: 1

--- a/Assets/Prefabs/NPCs/NPCJacen.prefab
+++ b/Assets/Prefabs/NPCs/NPCJacen.prefab
@@ -140,7 +140,7 @@ PrefabInstance:
     - target: {fileID: 6070195381934028526, guid: 0b19bdcdfd9aa4787988ef8a0c4d7715,
         type: 3}
       propertyPath: avoidancePriority
-      value: 20
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 8334725635003804250, guid: 0b19bdcdfd9aa4787988ef8a0c4d7715,
         type: 3}

--- a/Assets/Prefabs/NPCs/NPCRobin.prefab
+++ b/Assets/Prefabs/NPCs/NPCRobin.prefab
@@ -43,7 +43,7 @@ PrefabInstance:
     - target: {fileID: 6070195381934028526, guid: 0b19bdcdfd9aa4787988ef8a0c4d7715,
         type: 3}
       propertyPath: avoidancePriority
-      value: 30
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 8334725635003804250, guid: 0b19bdcdfd9aa4787988ef8a0c4d7715,
         type: 3}

--- a/Assets/Prefabs/NPCs/RealtorArmature.prefab
+++ b/Assets/Prefabs/NPCs/RealtorArmature.prefab
@@ -539,7 +539,7 @@ NavMeshAgent:
   m_Radius: 0.5
   m_Speed: 2
   m_Acceleration: 10
-  avoidancePriority: 10
+  avoidancePriority: 40
   m_AngularSpeed: 200
   m_StoppingDistance: 0
   m_AutoTraverseOffMeshLink: 1
@@ -586,7 +586,6 @@ MonoBehaviour:
   FootstepVolume: 0.5
   CurrentCheckUpOrigin: {fileID: 0}
   _sootheCooldown: 15
-  _minimumFearToSoothe: 4
 --- !u!114 &2200864632212857450
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NPC/States/CheckUpState.cs
+++ b/Assets/Scripts/NPC/States/CheckUpState.cs
@@ -63,6 +63,16 @@ public class CheckUpState : IState
         Vector3 randomDirection = Random.insideUnitSphere * _realtorController.CheckUpRadius;
         randomDirection += _realtorController.CurrentCheckUpOrigin.position;
         NavMesh.SamplePosition(randomDirection, out NavMeshHit hit, _realtorController.CheckUpRadius, 1);
+        
+        // Keep finding a point that is not behind a wall
+        int raycasts = 0;
+        int maxRaycasts = 3;
+        while (!Physics.Raycast(hit.position, _realtorController.CurrentCheckUpOrigin.position - hit.position,  _realtorController.CheckUpRadius, 1) && raycasts < maxRaycasts)
+        {
+            NavMesh.SamplePosition(randomDirection, out hit, _realtorController.CheckUpRadius, 1);
+            raycasts++;
+        }
+
         return hit.position;
     }
 }


### PR DESCRIPTION
## Description
Added a Raycast check to the sampled position on the NavMesh the Realtor chooses around the Visitor he is following. This ensures the actual point he chooses is inside the same room as the visitor.

Also reversed the NPC Priority, because i was dumb and set it up wrong before 

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes/UI and open the "Assignment" or "Final Exam" scene.
2. Press Play.
3. Open the console and try a command
4. Quit the level and go to level select
5. Select a level
6. Try the console again

## Fix Review
#### Realtor near Visitor
Criteria:
- [ ] The realtor doesn't stand on the other side of the wall of the npc he is following anymore (mostly used to happen near the bathroom)

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.