### PR TITLE
Fix: Button Map

### DIFF
--- a/Assets/Scenes/Assignment.unity
+++ b/Assets/Scenes/Assignment.unity
@@ -25060,6 +25060,11 @@ PrefabInstance:
     - target: {fileID: 679803723372703853, guid: 8c3d6af2977412d4c996eb20fc95379e,
         type: 3}
       propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223307540773076674, guid: 8c3d6af2977412d4c996eb20fc95379e,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7078945592317952038, guid: 8c3d6af2977412d4c996eb20fc95379e,

--- a/Assets/Scenes/FinalExam.unity
+++ b/Assets/Scenes/FinalExam.unity
@@ -24716,6 +24716,11 @@ PrefabInstance:
     - target: {fileID: 679803723372703853, guid: 8c3d6af2977412d4c996eb20fc95379e,
         type: 3}
       propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223307540773076674, guid: 8c3d6af2977412d4c996eb20fc95379e,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7078945592317952038, guid: 8c3d6af2977412d4c996eb20fc95379e,

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -75,12 +75,12 @@ public class GameManager : MonoBehaviour
 
     private void TogglePause()
     {
-        if (Time.timeScale == 0 && _pauseCanvas.activeSelf)
+        if (Time.timeScale == 0)
         {
             PlayerPrefs.Save();
             Time.timeScale = 1;
             AudioListener.pause = false;
-            _pauseCanvas.SetActive(false);
+            _pauseCanvas.GetComponent<PauseController>().TogglePause(false);
             Cursor.visible = false;
             Cursor.lockState = CursorLockMode.Locked;
             OnPauseToggled?.Invoke(false);
@@ -89,7 +89,7 @@ public class GameManager : MonoBehaviour
         {
             Time.timeScale = 0;
             AudioListener.pause = true;
-            _pauseCanvas.SetActive(true);
+            _pauseCanvas.GetComponent<PauseController>().TogglePause(true);
             Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;
             OnPauseToggled?.Invoke(true);

--- a/Assets/Scripts/UI/ButtonMappingController.cs
+++ b/Assets/Scripts/UI/ButtonMappingController.cs
@@ -9,15 +9,9 @@ public class ButtonMappingController : MonoBehaviour
     private void Awake()
     {
         _backButton.onClick.AddListener(OnBackButtonPressed);
-        _gameManager.OnPauseToggled += OnPauseToggled;
     }
 
     private void OnBackButtonPressed()
-    {
-        gameObject.SetActive(false);
-    }
-
-    private void OnPauseToggled(bool paused)
     {
         gameObject.SetActive(false);
     }

--- a/Assets/Scripts/UI/PauseController.cs
+++ b/Assets/Scripts/UI/PauseController.cs
@@ -14,6 +14,7 @@ public class PauseController : MonoBehaviour
     [SerializeField] private GameObject _options;
     [SerializeField] private GameObject _buttonMap;
     [SerializeField] private GameObject _quitConfirmation;
+    private Canvas _pauseCanvas;
 
     [Header("Progress References")]
     [SerializeField] private TextMeshProUGUI _timePassed;
@@ -30,11 +31,23 @@ public class PauseController : MonoBehaviour
     {
         SetupButtons();
         AddNpcOverlays();
+        _pauseCanvas = GetComponent<Canvas>();
     }
 
-    private void OnEnable()
+    public void TogglePause(bool enable)
     {
-        SetProgress(_gradeController.Grade);
+        if (enable)
+        {
+            _pauseCanvas.enabled = true;
+            SetProgress(_gradeController.Grade);
+        }
+        else
+        {
+            _buttonMap.SetActive(false);
+            _quitConfirmation.SetActive(false);
+            _options.SetActive(false);
+            _pauseCanvas.enabled = false;
+        }
     }
 
     private void SetupButtons()
@@ -47,12 +60,11 @@ public class PauseController : MonoBehaviour
 
     private void OnResumeButtonPressed()
     {
-        gameObject.SetActive(false);
+        TogglePause(false);
     }
 
     private void OnOptionsButtonPressed()
     {
-        gameObject.SetActive(false);
         _options.SetActive(true);
     }
 


### PR DESCRIPTION
## Description
Fixed the button map staying active when you pressed escape while it was open, now everytime the menu closes all other overlays close as well

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes/UI and open the "Assignment" or "Final Exam" scene.
2. Press Play.

## Fix Review
#### Realtor near Visitor
Criteria:
- [x] When pressing escape while the button map is active it closes as well

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.