### PR TITLE
Fix: Scare Cam over Tutorial

### DIFF
--- a/Assets/Scenes/Assignment.unity
+++ b/Assets/Scenes/Assignment.unity
@@ -51935,7 +51935,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 100
   m_TargetDisplay: 0
 --- !u!1 &1718719723
 GameObject:

--- a/Assets/Scenes/FinalExam.unity
+++ b/Assets/Scenes/FinalExam.unity
@@ -50075,7 +50075,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 100
   m_TargetDisplay: 0
 --- !u!1 &1718719723
 GameObject:


### PR DESCRIPTION
## Description
Scare cam is now over the tutorial.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes/UI and open the "Assigment" or "Main Menu" scene.
2. Press Play.
3. Trigger the scare cam while a tutorial is being displayed.

## Fix Review
#### Scare Cam Overlay
Criteria:
- [ ] Scare cam renders over tutorial

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.