### PR TITLE
Fix: NPC look being inconsistent and backbreaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ crashlytics-build.properties
 #Mac files
 .DS_Store
 .vsconfig
+Assets/com.rlabrecque.steamworks.net/Plugins/steam_api64.dll

--- a/Assets/Scripts/NPC/States/IdleState.cs
+++ b/Assets/Scripts/NPC/States/IdleState.cs
@@ -41,7 +41,11 @@ public class IdleState : IState
 
     private IEnumerator IdleCoroutine()
     {
+        _npcController.LookAt(_npcController.InspectTarget);
+        _npcController.StartCoroutine(_npcController.UpdateLookWeight(1f));
         yield return new WaitForSeconds(Random.Range(3f, 5f));
+        _npcController.StartCoroutine(_npcController.UpdateLookWeight(0f));
+        yield return new WaitUntil(() => _npcController.LookWeight <= 0.1f);
         if (IsIdle())
         {
             if (_npcController is VisitorController)

--- a/Assets/Scripts/NPC/States/InvestigateState.cs
+++ b/Assets/Scripts/NPC/States/InvestigateState.cs
@@ -36,6 +36,11 @@ public class InvestigateState : IState
     /// <returns></returns>
     private IEnumerator InvestigateCoroutine()
     {
+        if(_npcController.LookWeight > 0f)
+        {
+            _npcController.StartCoroutine(_npcController.UpdateLookWeight(0f));
+        }
+        yield return new WaitUntil(() => _npcController.LookWeight <= 0.1f);
         _npcController.Agent.speed = _npcController.InvestigatingSpeed;
         _npcController.Agent.stoppingDistance = 1f;
         _npcController.Agent.SetDestination(NearestPointOnTargetFromPlayer());
@@ -43,7 +48,7 @@ public class InvestigateState : IState
         // This while loop continues as long as the npc's navigation path is still being calculated (pathPending) 
         // or the remaining distance to the target is greater than the stopping distance. 
         // This ensures the NPC continues moving until it has reached its destination.
-
+        _npcController.StartCoroutine(_npcController.UpdateLookWeight(1f));
         while (_npcController.Agent.pathPending || _npcController.Agent.remainingDistance > _npcController.Agent.stoppingDistance)
         {
             if (_npcController.CurrentState is not InvestigateState)
@@ -55,9 +60,10 @@ public class InvestigateState : IState
         }
 
         yield return new WaitForSeconds(_investigateTime);
-
+        _npcController.StartCoroutine(_npcController.UpdateLookWeight(0f));
         if(IsInvestigating())
         {
+            yield return new WaitUntil(() => _npcController.LookWeight <= 0.1f);
             _npcController.CurrentState = _stateToReturnTo;
         }
     }

--- a/Assets/Scripts/NPC/States/PanickedState.cs
+++ b/Assets/Scripts/NPC/States/PanickedState.cs
@@ -22,6 +22,7 @@ public class PanickedState : IState
 
     private IEnumerator PanickedCoroutine()
     {
+        _visitorController.StartCoroutine(_visitorController.UpdateLookWeight(0f));
         _visitorController.Agent.speed = _visitorController.PanickedSpeed;
         _visitorController.Agent.stoppingDistance = 0f;
         _visitorController.Agent.SetDestination(_visitorController.PanickedTargetLocation.position);

--- a/Assets/Scripts/NPC/States/RoamState.cs
+++ b/Assets/Scripts/NPC/States/RoamState.cs
@@ -32,12 +32,9 @@ public class RoamState : IState
         {
             Transform inspectTarget = _visitorController.CurrentRoom.GetRandomInspectableObject(_visitorController.InspectTarget);
             _visitorController.InspectTarget = inspectTarget;
-            _visitorController.LookAt(inspectTarget);
             Vector3 newRoamLocation = GetClosestLocationToInspectTarget();
             _visitorController.Agent.SetDestination(newRoamLocation);
             yield return new WaitUntil(() => _visitorController.Agent.remainingDistance < 1f && !_visitorController.Agent.pathPending && IsRoaming());
-            _visitorController.InspectTarget = inspectTarget;
-            _visitorController.LookAt(inspectTarget);
             if(IsRoaming())
             {
                 _visitorController.CurrentState = _visitorController.IdleStateInstance;

--- a/Assets/Scripts/NPC/States/ScaredState.cs
+++ b/Assets/Scripts/NPC/States/ScaredState.cs
@@ -22,6 +22,7 @@ public class ScaredState : IState
 
     private IEnumerator ScaredCoroutine()
     {
+        _visitorController.StartCoroutine(_visitorController.UpdateLookWeight(0f));
         _visitorController.Agent.speed = _visitorController.PanickedSpeed;
         _visitorController.SwitchRooms();
         _visitorController.Agent.stoppingDistance = 0f;

--- a/Assets/Scripts/NPC/States/SootheState.cs
+++ b/Assets/Scripts/NPC/States/SootheState.cs
@@ -43,7 +43,7 @@ public class SootheState : IState
         _agent.isStopped = true;
         _agent.velocity = Vector3.zero;
         _animator.SetTrigger("Soothe");
-        _npcController.LookAt(Visitor.gameObject.GetComponent<VisitorSenses>().HeadTransform);
+        _npcController.StartCoroutine(LookAtSoothingSubject());
         _npcController.StartCoroutine(WaitForSoothe(Visitor));
     }
 
@@ -63,5 +63,16 @@ public class SootheState : IState
         _npcController.LookAt(_npcController.InspectTarget);
         _agent.isStopped = false;
         _npcController.CurrentState = _npcController.InvestigateStateInstance;
+    }
+
+    private IEnumerator LookAtSoothingSubject()
+    {
+        if(_npcController.LookWeight > 0f)
+        {
+            _npcController.StartCoroutine(_npcController.UpdateLookWeight(0f));
+        }
+        yield return new WaitUntil(() => _npcController.LookWeight <= 0.1f);
+        _npcController.LookAt(Visitor.gameObject.GetComponent<VisitorSenses>().HeadTransform);
+        _npcController.StartCoroutine(_npcController.UpdateLookWeight(1f));
     }
 }


### PR DESCRIPTION
## Description
Fixed NPC look being inconsistent and backbreaking by introducing a new way of increasing/decreasing lookweight.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Final Exam" scene.
2. Press Play.
3. Set your volume to 0 in the settings.

## Fix review
#### NPC Look
- [x] NPC looking around at targets should be way more consistent
- [x] When a NPC investigates, they turn their head and body consistently and appropriately.
- [x] When a NPC idles at an inspectable object, they turn their head and body consistently and appropriately.

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.