### PR TITLE
Change: The geist charge indicator only gets shown when its charging now.

### DIFF
--- a/Assets/Prefabs/UI/GeistChargeIndicator.prefab
+++ b/Assets/Prefabs/UI/GeistChargeIndicator.prefab
@@ -160,7 +160,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &3123530189253292883
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/GeistChargeLookingAtController.cs
+++ b/Assets/Scripts/Player/GeistChargeLookingAtController.cs
@@ -15,7 +15,7 @@ public class GeistChargeLookingAtController : MonoBehaviour
     {
         if (_previousGeistChargeIndicator != null)
         {
-            _previousGeistChargeIndicator.BeindLookedAt = false;
+            _previousGeistChargeIndicator.BeingLookedAt = false;
             _previousGeistChargeIndicator = null;
         }
         if (_visionController.LookingAt == null)
@@ -25,7 +25,7 @@ public class GeistChargeLookingAtController : MonoBehaviour
         GeistChargeIndicator geistChargeIndicator = _visionController.LookingAt.GetComponentInChildren<GeistChargeIndicator>();
         if (geistChargeIndicator != null)
         {
-            geistChargeIndicator.BeindLookedAt = true;
+            geistChargeIndicator.BeingLookedAt = true;
         }
         _previousGeistChargeIndicator = geistChargeIndicator;
     }


### PR DESCRIPTION
## Description
The geist charge indicator has been changed to only show when its actually charging.

## Setting up testing environment
1. In the project window navigate to Project/Assets/Scenes and open the "Final Exam" scene.
2. Press Play.
3. Set your volume to 0 in the settings.

## Change review
#### Geist charge
- [x] Geist charge indicator is only visible when an object has been used.
- [x] Geist charge indicator not shown when not looking or possesing it.
- [x] Broken objects don't have a geist charge indicator anymore.

## Checklist
_These checks should always be true for your pull request_
- [x] My pull request is for one story/feature.
- [x] Every individual commit in this pull request is logical.
- [x] All code, documentation, commits and player seen texts are in English.
- [x] I have deleted unused / unnecessary code.
- [x] If my edits need a change in documentation, then I have updated the documentation.
- [x] All code is in correspondence with the code conventions.